### PR TITLE
Fix broken link Inside the Python GIL (video)

### DIFF
--- a/where-to-go-from-here.html
+++ b/where-to-go-from-here.html
@@ -53,7 +53,7 @@
 <li><a href=http://docs.python.org/3.1/library/multiprocessing.html><code>multiprocessing</code> module</a>
 <li><a href=http://www.doughellmann.com/PyMOTW/multiprocessing/><code>multiprocessing</code>&nbsp;&mdash;&nbsp;Manage processes like threads</a>
 <li><a href=http://jessenoller.com/2009/02/01/python-threads-and-the-global-interpreter-lock/>Python threads and the Global Interpreter Lock</a> by Jesse Noller
-<li><a href=http://blip.tv/file/2232410>Inside the Python <abbr>GIL</abbr> (video)</a> by David Beazley
+<li><a href=https://www.youtube.com/watch?v=ph374fJqFPE>Inside the Python <abbr>GIL</abbr> (video)</a> by David Beazley
 </ul>
 
 <p>Metaclasses:


### PR DESCRIPTION
Updated the link for Inside the Python GIL (video). The previous link gave a '502 bad Gateway' error.